### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,8 @@ project(CleverSeg)
 # Extension meta-information
 set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerCleverSegmentation#cleversegmentation")
 set(EXTENSION_CATEGORY "Segmentation")
-set(EXTENSION_CONTRIBUTORS "Jonathan Ramos (University of São Paulo)")
-set(EXTENSION_DESCRIPTION "This is an example of a simple extension")
+set(EXTENSION_CONTRIBUTORS "Jonathan Ramos (ICMC, University of São Paulo - USP)")
+set(EXTENSION_DESCRIPTION "This is the implementation of the CleverSeg method that supports multi-label segmentations")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lassoan/SlicerCleverSegmentation/master/CleverSegmentation/Resources/Icons/CleverSegmentation.png")
 set(EXTENSION_SCREENSHOTURLS "https://user-images.githubusercontent.com/3834596/66679138-d7dc1700-ec43-11e9-8c36-51976a1121d3.png" "https://user-images.githubusercontent.com/3834596/66679174-f215f500-ec43-11e9-84f1-85f8b5c4d568.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a space separated string, a list or 'NA' if any


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.